### PR TITLE
Revert "Add AIDs for RFS module".

### DIFF
--- a/libcutils/include/private/android_filesystem_config.h
+++ b/libcutils/include/private/android_filesystem_config.h
@@ -139,9 +139,6 @@
 /* The range 2900-2999 is reserved for OEM, and must never be
  * used here */
 #define AID_OEM_RESERVED_START 2900
-#define AID_QCOM_DIAG 2950          /* access to QTI diagnostic resources */
-#define AID_RFS 2951                /* Remote Filesystem for peripheral processors */
-#define AID_RFS_SHARED 2952         /* Shared files for Remote Filesystem for peripheral processors */
 #define AID_OEM_RESERVED_END 2999
 
 /* The 3000 series are intended for use as supplemental group id's only.


### PR DESCRIPTION
This reverts commit 1fee8524b56351f422035a3d152d92996829ab3f.

This AIDs here are not needed anymore with new config_fs model.

Conflicts:
	libcutils/include/private/android_filesystem_config.h
@Discard: This AIDs here are no more needed with new config_fs model.
@topic:QC_Value_Added_Features
Change-Id: Idf31d1815142ed3309a694869f11383f0e6afab2